### PR TITLE
Restore the ability to bootstrap a 4.4 system

### DIFF
--- a/bootstrap/bootstrap.sh.json
+++ b/bootstrap/bootstrap.sh.json
@@ -110,12 +110,12 @@
 							"gpg": {
 								"key": {
 									"name": "Univention Corporate Server 4.x <container@univention.de>",
-									"hash": "6B6E7E3259A9F44F1452D1BE36602BA86B8BFD3C",
-									"file": "/usr/share/keyrings/univention-archive-key-ucs-4x.gpg",
-									"http": "https://updates.software-univention.de/univention-archive-key-ucs-4x.gpg",
+									"hash": "8321745BB32A82C75BBD4BC2D293E501A055F562",
+									"file": "/usr/share/keyrings/univention-archive-key-ucs-5x.gpg",
+									"http": "https://updates.software-univention.de/univention-archive-key-ucs-5x.gpg",
 									"date": {
-										"created": "2014-06-30",
-										"expire": "2021-06-28"
+										"created": "2020-05-08",
+										"expire": "2027-05-07"
 									}
 								}
 							},


### PR DESCRIPTION
## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [ ] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [ ] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=

## Description of the changes

Please describe the changes with a few sentences.

* https://help.univention.com/t/ucs-4-x-apt-key-expired-no-package-installation-update-app-installation-is-possible/18116
* The repo signing key for the 4.4 repo has expired and the repos have since then been signed with the 5.0 repo signing key
* correct the repo signing key in bootstrap information to be able to bootstrap a 4.4 system
